### PR TITLE
Load default.js if it exists

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -18,9 +18,12 @@ pageMod.PageMod({
             if (domain.indexOf('www.') === 0) {
                 domain = domain.substring(4, domain.length);
             }
-            var filename = '~/.js/' + domain + '.js';
-            if (file.exists(filename)) {
-                worker.postMessage(file.read(filename));
+            var files = ['default', domain];
+            for (var i=0; i < files.length; i++) {
+                filename = '~/.js/' + files[i] + '.js';
+                if (file.exists(filename)) {
+                    worker.postMessage(file.read(filename));
+                }
             }
         });
     }


### PR DESCRIPTION
The only feature missing from this was the ability to load `~/.js/default.js`. This commit brings said feature.
