### PR TITLE
Added support for CSS-files

### DIFF
--- a/data/dotjs.js
+++ b/data/dotjs.js
@@ -10,6 +10,9 @@ self.on("message", function(msg) {
         }).call(window); // coffee-script.js assumes this === window
         eval(CoffeeScript.compile(msg.coffee));
     }
+    if (msg.css) {
+        $('head').append($('<style>').text(msg.css));
+    }
 });
 
 self.postMessage(document.URL);

--- a/lib/main.js
+++ b/lib/main.js
@@ -18,6 +18,7 @@ pageMod.PageMod({
                     .getService(Ci.nsIProperties),
                 homeDir = dirSvc.get('Home', Ci.nsIFile).path,
                 jsDir = homeDir.indexOf('/') === 0 ? '.js' : 'js',
+                cssDir = homeDir.indexOf('/') === 0 ? '.css' : 'css',
                 files, filename;
             if (domain.indexOf('www.') === 0) {
                 domain = domain.substring(4, domain.length);
@@ -34,6 +35,12 @@ pageMod.PageMod({
                     worker.postMessage({
                         coffee: file.read(filename + '.coffee'),
                         transpiler: data.load('coffee-script.js')
+                    });
+                }
+                cssname = file.join(homeDir, cssDir, files[i]);
+                if (file.exists(cssname + '.css')) {
+                    worker.postMessage({
+                        css: file.read(cssname + '.css')
                     });
                 }
             }


### PR DESCRIPTION
Modified the plugin to look for CSS-files in `~/.css` and appends them to head as simple style-tags. The files could probably be placed in the same directory as the JS-files, without cluttering the structure too much, but kept separate for cleanliness.

I don't know if this is wanted or not, but it would make the plugin more complete for me.
