### PR TITLE
Inject scripts on document ready

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -5,6 +5,7 @@ const data = require('self').data,
 require("page-mod").PageMod({
     include: "*",
     contentScriptFile: data.url('dotjs.js'),
+    contentScriptWhen: 'ready',
     onAttach: function (worker) {
         worker.port.on('init', function(domain) {
             let host = url.URL(domain).host;


### PR DESCRIPTION
Huge speed improvement :-)

In most cases, the document ready event is what a developer want. If necessary, it’s easy to use `window.addEventListener('load', …)` to listen for the window onload event.
