### PR TITLE
Changes to new sdk module paths

### DIFF
--- a/lib/dotjs.js
+++ b/lib/dotjs.js
@@ -1,6 +1,6 @@
 const {Cc, Ci} = require('chrome'); 
-const data = require("self").data;
-const file = require('file');
+const data = require("sdk/self").data;
+const file = require('sdk/io/file');
 const dirSvc = Cc['@mozilla.org/file/directory_service;1'].getService(Ci.nsIProperties),
 homeDir = dirSvc.get('Home', Ci.nsIFile).path,
 jsDir = homeDir.indexOf('/') === 0 ? '.js' : 'js';

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,8 +1,8 @@
-const data = require('self').data,
-    url = require('url'),
-    matchFile = require("dotjs").matchFile;
+const data = require('sdk/self').data,
+    url = require('sdk/url'),
+    matchFile = require("./dotjs").matchFile;
 
-require("page-mod").PageMod({
+require("sdk/page-mod").PageMod({
     include: "*",
     contentScriptFile: data.url('dotjs.js'),
     contentScriptWhen: 'ready',

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
     "name": "dotjs", 
     "license": "BSD",
     "author": "Ricky Rosario", 
-    "version": "1.11",
+    "version": "1.11.0",
     "fullName": "dotjs", 
-    "id": "jid0-HC7vB1GcMVr7IBB5B5ADUjTJB3U", 
+    "main": "lib/main.js",
     "description": "Add-on that executes JavaScript and CoffeeScript scripts from ~/.js and loads CSS files from ~/.css based on the site domain."
 }


### PR DESCRIPTION
Included are the changes necessary to get dotjs to compile with Firefox (41.0b5)